### PR TITLE
feat!: Rename module and format

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/" 
     schedule:
-      interval: "daily"
+      interval: "weekly"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,9 +1,17 @@
 name: Go
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
 
 jobs:
-
   test:
     name: Test
     runs-on: ${{ matrix.os }}
@@ -14,42 +22,34 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ['1.19', '1.20','1.21']
+        go: ["1.22", "1.23", "1.24"]
       fail-fast: false
     env:
       OS: ${{ matrix.os }}
       GO: ${{ matrix.go }}
     steps:
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go }}
+          cache: false
 
       - if: startsWith(matrix.os, 'macos')
         run: |
           brew update
-          brew install openssl@3
           brew install sqlite
           go env -w CGO_CFLAGS="$(go env CGO_CFLAGS) -I/opt/homebrew/opt/openssl/include"
           go env -w CGO_LDFLAGS="$(go env CGO_LDFLAGS) -L/opt/homebrew/opt/openssl/lib"
 
-      - name: Get Build Tools
-        run: |
-          GO111MODULE=on go install github.com/ory/go-acc@latest
-
-      - name: Add $GOPATH/bin to $PATH
-        run: |
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
-
       - uses: actions/checkout@v4
 
-      - name: 'Tags: default'
-        run: go-acc . -- -race -v -tags ""
+      - name: "Tags: default"
+        run: go test -race -v -coverprofile=coverage.out -tags ""
 
-      - name: 'Tags: libsqlite3'
-        run: go-acc . -- -race -v -tags "libsqlite3"
+      - name: "Tags: libsqlite3"
+        run: go test -race -v -coverprofile=coverage.out -tags "libsqlite3"
 
-      - name: 'Tags: vacuum'
-        run: go-acc . -- -race -v -tags "sqlite_vacuum_full"
+      - name: "Tags: vacuum"
+        run: go test -race -v -coverprofile=coverage.out -tags "sqlite_vacuum_full"
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
@@ -65,7 +65,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ['1.19', '1.20','1.21']
+        go: ["1.22", "1.23", "1.24"]
       fail-fast: false
     env:
       OS: windows-latest
@@ -89,21 +89,21 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: 'Tags: default'
+      - name: "Tags: default"
         run: go build -race -v -tags ""
         shell: msys2 {0}
 
-      - name: 'Tags: libsqlite3'
+      - name: "Tags: libsqlite3"
         run: go build -race -v -tags "libsqlite3"
         shell: msys2 {0}
 
-      - name: 'Tags: full'
+      - name: "Tags: full"
         run: |
           echo 'skip this test'
           echo go build -race -v -tags "sqlite_allow_uri_authority sqlite_app_armor sqlite_column_metadata sqlite_foreign_keys sqlite_fts5 sqlite_icu sqlite_introspect sqlite_json sqlite_math_functions sqlite_preupdate_hook sqlite_secure_delete sqlite_see sqlite_stat4 sqlite_trace sqlite_unlock_notify sqlite_userauth sqlite_vacuum_incr sqlite_vtable"
         shell: msys2 {0}
 
-      - name: 'Tags: vacuum'
+      - name: "Tags: vacuum"
         run: go build -race -v -tags "sqlite_vacuum_full"
         shell: msys2 {0}
 
@@ -111,5 +111,3 @@ jobs:
         uses: codecov/codecov-action@v3
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-# based on: github.com/koron-go/_skeleton/.github/workflows/go.yml

--- a/README.md
+++ b/README.md
@@ -1,20 +1,15 @@
-go-sqlite3
-==========
+# go-sqlcipher
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/ValentinMontmirail/go-sqlcipher.svg)](https://pkg.go.dev/github.com/ValentinMontmirail/go-sqlcipher)
-[![Github Action](https://github.com/ValentinMontmirail/go-sqlcipher/actions/workflows/go.yaml/badge.svg)](https://github.com/ValentinMontmirail/go-sqlcipher/actions/workflows/go.yaml)
-[![Coverage Status](https://codecov.io/gh/ValentinMontmirail/go-sqlcipher/graph/badge.svg?token=6FK2UKVH2X)](https://codecov.io/gh/ValentinMontmirail/go-sqlcipher)
-[![Go Report Card](https://goreportcard.com/badge/github.com/ValentinMontmirail/go-sqlcipher)](https://goreportcard.com/report/github.com/ValentinMontmirail/go-sqlcipher)
-[![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=ValentinMontmirail_go-sqlcipher&metric=ncloc)](https://sonarcloud.io/summary/new_code?id=ValentinMontmirail_go-sqlcipher)
+[![Go Reference](https://pkg.go.dev/badge/github.com/SE-I-T-Digital/go-sqlcipher.svg)](https://pkg.go.dev/github.com/SE-I-T-Digital/go-sqlcipher)
+[![Github Action](https://github.com/SE-I-T-Digital/go-sqlcipher/actions/workflows/go.yaml/badge.svg)](https://github.com/SE-I-T-Digital/go-sqlcipher/actions/workflows/go.yaml)
+[![Coverage Status](https://codecov.io/gh/SE-I-T-Digital/go-sqlcipher/graph/badge.svg?token=6FK2UKVH2X)](https://codecov.io/gh/SE-I-T-Digital/go-sqlcipher)
+[![Go Report Card](https://goreportcard.com/badge/github.com/SE-I-T-Digital/go-sqlcipher)](https://goreportcard.com/report/github.com/SE-I-T-Digital/go-sqlcipher)
 
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=ValentinMontmirail_go-sqlcipher&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=ValentinMontmirail_go-sqlcipher)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=ValentinMontmirail_go-sqlcipher&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=ValentinMontmirail_go-sqlcipher)
-[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=ValentinMontmirail_go-sqlcipher&metric=sqale_rating)](https://sonarcloud.io/summary/new_code?id=ValentinMontmirail_go-sqlcipher)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ValentinMontmirail_go-sqlcipher&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=ValentinMontmirail_go-sqlcipher)
+[`go-sqlite3`](https://github.com/mattn/go-sqlite3) ➕ [`sqlcipher`](https://github.com/sqlcipher/sqlcipher)
 
-# Description
+## Description
 
-A sqlite3 driver that conforms to the built-in database/sql interface.
+A sqlite3 driver that conforms to the built-in `database/sql` interface.
 
 Supported Golang version: See [.github/workflows/go.yaml](./.github/workflows/go.yaml).
 
@@ -24,16 +19,16 @@ Current supported version of SQLite 3: `3.49.2`
 
 ### Overview
 
-- [go-sqlite3](#go-sqlite3)
+- [go-sqlcipher](#go-sqlcipher)
 - [Description](#description)
-    - [Overview](#overview)
+  - [Overview](#overview)
 - [Installation](#installation)
 - [API Reference](#api-reference)
 - [Connection String](#connection-string)
   - [DSN Examples](#dsn-examples)
 - [Features](#features)
-    - [Usage](#usage)
-    - [Feature / Extension List](#feature--extension-list)
+  - [Usage](#usage)
+  - [Feature / Extension List](#feature--extension-list)
 - [Compilation](#compilation)
   - [Android](#android)
 - [ARM](#arm)
@@ -49,7 +44,7 @@ Current supported version of SQLite 3: `3.49.2`
   - [Errors](#errors)
 - [User Authentication](#user-authentication)
   - [Compile](#compile)
-  - [Usage](#usage-1)
+  - [Usage](#user-authentication-usage)
     - [Create protected database](#create-protected-database)
     - [Password Encoding](#password-encoding)
       - [Available Encoders](#available-encoders)
@@ -67,27 +62,30 @@ Current supported version of SQLite 3: `3.49.2`
   - [Workspace Configuration](#workspace-configuration)
   - [Updating SQLite](#updating-sqlite)
 - [License](#license)
-- [Author](#author)
+- [Authors](#authors)
 
-# Installation
+## Installation
 
 This package can be installed with the `go get` command:
 
-    go get github.com/ValentinMontmirail/go-sqlcipher
+```bash
+go get github.com/SE-I-T-Digital/go-sqlcipher
+```
 
-_go-sqlite3_ is *cgo* package.
-If you want to build your app using go-sqlite3, you need gcc.
-However, after you have built and installed _go-sqlite3_ with `go install github.com/ValentinMontmirail/go-sqlcipher` (which requires gcc), you can build your app without relying on gcc in future.
+_go-sqlite3_ is _cgo_ package.
+If you want to build your app using go-sqlite3, you need `gcc`.
+However, after you have built and installed _go-sqlite3_ with `go install github.com/SE-I-T-Digital/go-sqlcipher` (which requires gcc), you can build your app without relying on gcc in future.
 
-***Important: because this is a `CGO` enabled package, you are required to set the environment variable `CGO_ENABLED=1` and have a `gcc` compile present within your path.***
+> [!IMPORTANT]
+> Because this is a `CGO` enabled package, you are required to set the environment variable `CGO_ENABLED=1` and have a `gcc` compile present within your path.
 
-# API Reference
+## API Reference
 
-API documentation can be found [here](http://godoc.org/github.com/ValentinMontmirail/go-sqlcipher).
+API documentation can be found on [pkg.go.dev](https://pkg.go.dev/github.com/SE-I-T-Digital/go-sqlcipher).
 
 Examples can be found under the [examples](./_example) directory.
 
-# Connection String
+## Connection String
 
 When creating a new SQLite database or connection to an existing one, with the file name additional options can be given.
 This is also known as a DSN (Data Source Name) string.
@@ -103,8 +101,9 @@ Options can be given using the following format: `KEYWORD=VALUE` and multiple op
 This library supports DSN options of SQLite itself and provides additional options.
 
 Boolean values can be one of:
-* `0` `no` `false` `off`
-* `1` `yes` `true` `on`
+
+- `0` `no` `false` `off`
+- `1` `yes` `true` `on`
 
 | Name | Key | Value(s) | Description |
 |------|-----|----------|-------------|
@@ -134,18 +133,17 @@ Boolean values can be one of:
 | Writable Schema | `_writable_schema` | `Boolean` | When this pragma is on, the SQLITE_MASTER tables in which database can be changed using ordinary UPDATE, INSERT, and DELETE statements. Warning: misuse of this pragma can easily result in a corrupt database file. |
 | Cache Size | `_cache_size` | `int` | Maximum cache size; default is 2000K (2M). See [PRAGMA cache_size](https://sqlite.org/pragma.html#pragma_cache_size) |
 
+### DSN Examples
 
-## DSN Examples
-
-```
+```txt
 file:test.db?cache=shared&mode=memory
 ```
 
-# Features
+## Features
 
 This package allows additional configuration of features available within SQLite3 to be enabled or disabled by golang build constraints also known as build `tags`.
 
-Click [here](https://golang.org/pkg/go/build/#hdr-Build_Constraints) for more information about build tags / constraints.
+Click for more information about [build tags / constraints](https://golang.org/pkg/go/build/#hdr-Build_Constraints).
 
 ### Usage
 
@@ -173,7 +171,7 @@ go build -tags "icu json1 fts5 secure_delete"
 | App Armor | sqlite_app_armor | When defined, this C-preprocessor macro activates extra code that attempts to detect misuse of the SQLite API, such as passing in NULL pointers to required parameters or using objects after they have been destroyed. <br><br>App Armor is not available under `Windows`. |
 | Disable Load Extensions | sqlite_omit_load_extension | Loading of external extensions is enabled by default.<br><br>To disable extension loading add the build tag `sqlite_omit_load_extension`. |
 | Enable Serialization with `libsqlite3` | sqlite_serialize | Serialization and deserialization of a SQLite database is available by default, unless the build tag `libsqlite3` is set.<br><br>To enable this functionality even if `libsqlite3` is set, add the build tag `sqlite_serialize`. |
-| Foreign Keys | sqlite_foreign_keys | This macro determines whether enforcement of foreign key constraints is enabled or disabled by default for new database connections.<br><br>Each database connection can always turn enforcement of foreign key constraints on and off and run-time using the foreign_keys pragma.<br><br>Enforcement of foreign key constraints is normally off by default, but if this compile-time parameter is set to 1, enforcement of foreign key constraints will be on by default | 
+| Foreign Keys | sqlite_foreign_keys | This macro determines whether enforcement of foreign key constraints is enabled or disabled by default for new database connections.<br><br>Each database connection can always turn enforcement of foreign key constraints on and off and run-time using the foreign_keys pragma.<br><br>Enforcement of foreign key constraints is normally off by default, but if this compile-time parameter is set to 1, enforcement of foreign key constraints will be on by default |
 | Full Auto Vacuum | sqlite_vacuum_full | Set the default auto vacuum to full |
 | Incremental Auto Vacuum | sqlite_vacuum_incr | Set the default auto vacuum to incremental |
 | Full Text Search Engine | sqlite_fts5 | When this option is defined in the amalgamation, versions 5 of the full-text search engine (fts5) is added to the build automatically |
@@ -187,15 +185,15 @@ go build -tags "icu json1 fts5 secure_delete"
 | Secure Delete (FAST) | sqlite_secure_delete_fast | For more information see [PRAGMA secure_delete](https://www.sqlite.org/pragma.html#pragma_secure_delete) |
 | Tracing / Debug | sqlite_trace | Activate trace functions |
 | User Authentication | sqlite_userauth | SQLite User Authentication see [User Authentication](#user-authentication) for more information. |
-| Virtual Tables | sqlite_vtable | SQLite Virtual Tables see [SQLite Official VTABLE Documentation](https://www.sqlite.org/vtab.html) for more information, and a [full example here](https://github.com/ValentinMontmirail/go-sqlcipher/tree/master/_example/vtable) |
+| Virtual Tables | sqlite_vtable | SQLite Virtual Tables see [SQLite Official VTABLE Documentation](https://www.sqlite.org/vtab.html) for more information, and a [full example here](https://github.com/mattn/go-sqlite3/tree/master/_example/vtable) |
 
-# Compilation
+## Compilation
 
 This package requires the `CGO_ENABLED=1` environment variable if not set by default, and the presence of the `gcc` compiler.
 
 If you need to add additional CFLAGS or LDFLAGS to the build command, and do not want to modify this package, then this can be achieved by using the `CGO_CFLAGS` and `CGO_LDFLAGS` environment variables.
 
-## Android
+### Android
 
 This package can be compiled for android.
 Compile with:
@@ -204,9 +202,9 @@ Compile with:
 go build -tags "android"
 ```
 
-For more information see [#201](https://github.com/ValentinMontmirail/go-sqlcipher/issues/201)
+For more information see [#201](https://github.com/mattn/go-sqlite3/issues/201)
 
-# ARM
+### ARM
 
 To compile for `ARM` use the following environment:
 
@@ -217,31 +215,34 @@ env CC=arm-linux-gnueabihf-gcc CXX=arm-linux-gnueabihf-g++ \
 ```
 
 Additional information:
-- [#242](https://github.com/ValentinMontmirail/go-sqlcipher/issues/242)
-- [#504](https://github.com/ValentinMontmirail/go-sqlcipher/issues/504)
 
-# Cross Compile
+- [#242](https://github.com/mattn/go-sqlite3/issues/242)
+- [#504](https://github.com/mattn/go-sqlite3/issues/504)
+
+### Cross Compile
 
 This library can be cross-compiled.
 
 In some cases you are required to the `CC` environment variable with the cross compiler.
 
-## Cross Compiling from macOS
+#### Cross Compiling from macOS
+
 The simplest way to cross compile from macOS is to use [xgo](https://github.com/karalabe/xgo).
 
 Steps:
+
 - Install [musl-cross](https://github.com/FiloSottile/homebrew-musl-cross) (`brew install FiloSottile/musl-cross/musl-cross`).
 - Run `CC=x86_64-linux-musl-gcc CXX=x86_64-linux-musl-g++ GOARCH=amd64 GOOS=linux CGO_ENABLED=1 go build -ldflags "-linkmode external -extldflags -static"`.
 
 Please refer to the project's [README](https://github.com/FiloSottile/homebrew-musl-cross#readme) for further information.
 
-# Google Cloud Platform
+### Google Cloud Platform
 
 Building on GCP is not possible because Google Cloud Platform does not allow `gcc` to be executed.
 
 Please work only with compiled final binaries.
 
-## Linux
+### Linux
 
 To compile this package on Linux, you must install the development tools for your linux distribution.
 
@@ -253,31 +254,31 @@ go build -tags "linux"
 
 If you wish to link directly to libsqlite3 then you can use the `libsqlite3` build tag.
 
-```
+```bash
 go build -tags "libsqlite3 linux"
 ```
 
-### Alpine
+#### Alpine
 
 When building in an `alpine` container  run the following command before building:
 
-```
+```bash
 apk add --update gcc musl-dev
 ```
 
-### Fedora
+#### Fedora
 
 ```bash
 sudo yum groupinstall "Development Tools" "Development Libraries"
 ```
 
-### Ubuntu
+#### Ubuntu
 
 ```bash
 sudo apt-get install build-essential
 ```
 
-## macOS
+### macOS
 
 macOS should have all the tools present to compile this package. If not, install XCode to add all the developers tools.
 
@@ -309,7 +310,7 @@ go build -tags "darwin arm64"
 
 If you wish to link directly to libsqlite3, use the `libsqlite3` build tag:
 
-```
+```zsh
 # x86 
 go build -tags "libsqlite3 darwin amd64"
 # ARM
@@ -317,21 +318,22 @@ go build -tags "libsqlite3 darwin arm64"
 ```
 
 Additional information:
-- [#206](https://github.com/ValentinMontmirail/go-sqlcipher/issues/206)
-- [#404](https://github.com/ValentinMontmirail/go-sqlcipher/issues/404)
+
+- [#206](https://github.com/mattn/go-sqlite3/issues/206)
+- [#404](https://github.com/mattn/go-sqlite3/issues/404)
 
 ## Windows
 
 To compile this package on Windows, you must have the `gcc` compiler installed.
 
-1) Install a Windows `gcc` toolchain.
-2) Add the `bin` folder to the Windows path, if the installer did not do this by default.
-3) Open a terminal for the TDM-GCC toolchain, which can be found in the Windows Start menu.
-4) Navigate to your project folder and run the `go build ...` command for this package.
+1. Install a Windows `gcc` toolchain.
+2. Add the `bin` folder to the Windows path, if the installer did not do this by default.
+3. Open a terminal for the TDM-GCC toolchain, which can be found in the Windows Start menu.
+4. Navigate to your project folder and run the `go build ...` command for this package.
 
-For example the TDM-GCC Toolchain can be found [here](https://jmeubank.github.io/tdm-gcc/).
+See the [TDM-GCC Toolchain](https://jmeubank.github.io/tdm-gcc/).
 
-## Errors
+### Errors
 
 - Compile error: `can not be used when making a shared object; recompile with -fPIC`
 
@@ -344,34 +346,34 @@ For example the TDM-GCC Toolchain can be found [here](https://jmeubank.github.io
     go build -ldflags '-extldflags=-fno-PIC'
     ```
 
-    More details see [#120](https://github.com/ValentinMontmirail/go-sqlcipher/issues/120)
+    More details see [#120](https://github.com/mattn/go-sqlite3/issues/120)
 
 - Can't build go-sqlite3 on windows 64bit.
 
     > Probably, you are using go 1.0, go1.0 has a problem when it comes to compiling/linking on windows 64bit.
-    > See: [#27](https://github.com/ValentinMontmirail/go-sqlcipher/issues/27)
+    > See: [#27](https://github.com/mattn/go-sqlite3/issues/27)
 
-- `go get github.com/ValentinMontmirail/go-sqlcipher` throws compilation error.
+- `go get github.com/SE-I-T-Digital/go-sqlcipher` throws compilation error.
 
     `gcc` throws: `internal compiler error`
 
     Remove the download repository from your disk and try re-install with:
 
     ```bash
-    go install github.com/ValentinMontmirail/go-sqlcipher
+    go install github.com/SE-I-T-Digital/go-sqlcipher
     ```
 
-# User Authentication
+## User Authentication
 
 This package supports the SQLite User Authentication module.
 
-## Compile
+### Compile
 
 To use the User authentication module, the package has to be compiled with the tag `sqlite_userauth`. See [Features](#features).
 
-## Usage
+### User Authentication Usage
 
-### Create protected database
+#### Create protected database
 
 To create a database protected by user authentication, provide the following argument to the connection string `_auth`.
 This will enable user authentication within the database. This option however requires two additional arguments:
@@ -392,7 +394,7 @@ Create an user authentication database with user `admin` and password `admin` an
 
 `file:test.s3db?_auth&_auth_user=admin&_auth_pass=admin&_auth_crypt=sha1`
 
-### Password Encoding
+#### Password Encoding
 
 The passwords within the user authentication module of SQLite are encoded with the SQLite function `sqlite_cryp`.
 This function uses a ceasar-cypher which is quite insecure.
@@ -412,11 +414,11 @@ salt this can be configured with `_auth_salt`.
 - SHA512
 - SSHA512 (salted SHA512)
 
-### Restrictions
+#### Restrictions
 
 Operations on the database regarding user management can only be preformed by an administrator user.
 
-### Support
+#### Support
 
 The user authentication supports two kinds of users:
 
@@ -472,16 +474,16 @@ The following functions are available for User authentication from the `*SQLiteC
 
 When using attached databases, SQLite will use the authentication from the `main` database for the attached database(s).
 
-# Extensions
+## Extensions
 
 If you want your own extension to be listed here, or you want to add a reference to an extension; please submit an Issue for this.
 
-## Spatialite
+### Spatialite
 
 Spatialite is available as an extension to SQLite, and can be used in combination with this repository.
 For an example, see [shaxbee/go-spatialite](https://github.com/shaxbee/go-spatialite).
 
-## extension-functions.c from SQLite3 Contrib
+### extension-functions.c from SQLite3 Contrib
 
 extension-functions.c is available as an extension to SQLite, and provides the following functions:
 
@@ -491,15 +493,15 @@ extension-functions.c is available as an extension to SQLite, and provides the f
 
 For an example, see [dinedal/go-sqlite3-extension-functions](https://github.com/dinedal/go-sqlite3-extension-functions).
 
-# Developer Instructions
+## Developer Instructions
 
-## Workspace Configuration
+### Workspace Configuration
 
 1. Install `openssl`
 2. Configure `CGO_CFLAGS` and `CGO_LDFLAGS` go environment variables
 3. Update `.vscode/c_cpp_properties.json` with the `openssl` include path used in `CGO_CFLAGS`
 
-### Example for Mac OSx with homebrew
+#### Example for Mac OSx with homebrew
 
 ```sh
 brew update
@@ -529,7 +531,7 @@ go env -w CGO_LDFLAGS="$(go env CGO_LDFLAGS) -L/opt/homebrew/opt/openssl/lib"
 }
 ```
 
-## Updating SQLite
+### Updating SQLite
 
 1. Clone the following repository: [sqlcipher-amalgamation](https://github.com/chehrlic/sqlcipher-amalgamation)
 2. In the `create_amalgamation.sh` script, update the version of `sqlcipher` to target (if necessary)
@@ -559,18 +561,19 @@ go env -w CGO_LDFLAGS="$(go env CGO_LDFLAGS) -L/opt/homebrew/opt/openssl/lib"
 > [!IMPORTANT]
 > Do not modify the `SQLITE_USER_AUTHENTICATION` section in `sqlite3-binding.h`.
 
-# License
+## License
 
-MIT: http://mattn.mit-license.org/2018
+MIT: [Original](http://mattn.mit-license.org/2018)
 
-sqlite3-binding.c, sqlite3-binding.h, sqlite3ext.h
+### sqlite3-binding.c, sqlite3-binding.h, sqlite3ext.h
 
-The -binding suffix was added to avoid build failures under gccgo.
+The `-binding` suffix was added to avoid build failures under gccgo.
 
 In this repository, those files are an amalgamation of code that was copied from SQLite3. The license of that code is the same as the license of SQLite3.
 
-# Author
+## Authors
 
-Yasuhiro Matsumoto (a.k.a mattn)
-G.J.R. Timmer
-Valentin Montmirail
+- Yasuhiro Matsumoto (a.k.a mattn)
+- G.J.R. Timmer
+- Valentin Montmirail
+- SE-I-T-Digital

--- a/backup_test.go
+++ b/backup_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sqlite3

--- a/callback_test.go
+++ b/callback_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sqlite3

--- a/doc.go
+++ b/doc.go
@@ -5,63 +5,63 @@ This works as a driver for database/sql.
 
 Installation
 
-    go get github.com/xeodou/go-sqlcipher
+	go get github.com/xeodou/go-sqlcipher
 
-Supported Types
+# Supported Types
 
 Currently, go-sqlite3 supports the following data types.
 
-    +------------------------------+
-    |go        | sqlite3           |
-    |----------|-------------------|
-    |nil       | null              |
-    |int       | integer           |
-    |int64     | integer           |
-    |float64   | float             |
-    |bool      | integer           |
-    |[]byte    | blob              |
-    |string    | text              |
-    |time.Time | timestamp/datetime|
-    +------------------------------+
+	+------------------------------+
+	|go        | sqlite3           |
+	|----------|-------------------|
+	|nil       | null              |
+	|int       | integer           |
+	|int64     | integer           |
+	|float64   | float             |
+	|bool      | integer           |
+	|[]byte    | blob              |
+	|string    | text              |
+	|time.Time | timestamp/datetime|
+	+------------------------------+
 
-SQLite3 Extension
+# SQLite3 Extension
 
 You can write your own extension module for sqlite3. For example, below is an
 extension for a Regexp matcher operation.
 
-    #include <pcre.h>
-    #include <string.h>
-    #include <stdio.h>
-    #include <sqlite3ext.h>
+	#include <pcre.h>
+	#include <string.h>
+	#include <stdio.h>
+	#include <sqlite3ext.h>
 
-    SQLITE_EXTENSION_INIT1
-    static void regexp_func(sqlite3_context *context, int argc, sqlite3_value **argv) {
-      if (argc >= 2) {
-        const char *target  = (const char *)sqlite3_value_text(argv[1]);
-        const char *pattern = (const char *)sqlite3_value_text(argv[0]);
-        const char* errstr = NULL;
-        int erroff = 0;
-        int vec[500];
-        int n, rc;
-        pcre* re = pcre_compile(pattern, 0, &errstr, &erroff, NULL);
-        rc = pcre_exec(re, NULL, target, strlen(target), 0, 0, vec, 500);
-        if (rc <= 0) {
-          sqlite3_result_error(context, errstr, 0);
-          return;
-        }
-        sqlite3_result_int(context, 1);
-      }
-    }
+	SQLITE_EXTENSION_INIT1
+	static void regexp_func(sqlite3_context *context, int argc, sqlite3_value **argv) {
+	  if (argc >= 2) {
+	    const char *target  = (const char *)sqlite3_value_text(argv[1]);
+	    const char *pattern = (const char *)sqlite3_value_text(argv[0]);
+	    const char* errstr = NULL;
+	    int erroff = 0;
+	    int vec[500];
+	    int n, rc;
+	    pcre* re = pcre_compile(pattern, 0, &errstr, &erroff, NULL);
+	    rc = pcre_exec(re, NULL, target, strlen(target), 0, 0, vec, 500);
+	    if (rc <= 0) {
+	      sqlite3_result_error(context, errstr, 0);
+	      return;
+	    }
+	    sqlite3_result_int(context, 1);
+	  }
+	}
 
-    #ifdef _WIN32
-    __declspec(dllexport)
-    #endif
-    int sqlite3_extension_init(sqlite3 *db, char **errmsg,
-          const sqlite3_api_routines *api) {
-      SQLITE_EXTENSION_INIT2(api);
-      return sqlite3_create_function(db, "regexp", 2, SQLITE_UTF8,
-          (void*)db, regexp_func, NULL, NULL);
-    }
+	#ifdef _WIN32
+	__declspec(dllexport)
+	#endif
+	int sqlite3_extension_init(sqlite3 *db, char **errmsg,
+	      const sqlite3_api_routines *api) {
+	  SQLITE_EXTENSION_INIT2(api);
+	  return sqlite3_create_function(db, "regexp", 2, SQLITE_UTF8,
+	      (void*)db, regexp_func, NULL, NULL);
+	}
 
 It needs to be built as a so/dll shared library. And you need to register
 the extension module like below.
@@ -77,7 +77,7 @@ Then, you can use this extension.
 
 	rows, err := db.Query("select text from mytable where name regexp '^golang'")
 
-Connection Hook
+# Connection Hook
 
 You can hook and inject your code when the connection is established. database/sql
 doesn't provide a way to get native go-sqlite3 interfaces. So if you want,
@@ -91,7 +91,7 @@ you need to set ConnectHook and get the SQLiteConn.
 					},
 			})
 
-Go SQlite3 Extensions
+# Go SQlite3 Extensions
 
 If you want to register Go functions as SQLite extension functions,
 call RegisterFunction from ConnectHook.
@@ -107,6 +107,5 @@ call RegisterFunction from ConnectHook.
 			})
 
 See the documentation of RegisterFunc for more details.
-
 */
 package sqlite3

--- a/error_test.go
+++ b/error_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sqlite3

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ValentinMontmirail/go-sqlcipher
+module github.com/SE-I-T-Digital/go-sqlcipher
 
 go 1.18
 

--- a/sqlite3_go18.go
+++ b/sqlite3_go18.go
@@ -3,8 +3,8 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
-// +build cgo
-// +build go1.8
+//go:build cgo && go1.8
+// +build cgo,go1.8
 
 package sqlite3
 

--- a/sqlite3_go18_test.go
+++ b/sqlite3_go18_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build go1.8 && cgo
 // +build go1.8,cgo
 
 package sqlite3

--- a/sqlite3_load_extension.go
+++ b/sqlite3_load_extension.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !sqlite_omit_load_extension
 // +build !sqlite_omit_load_extension
 
 package sqlite3

--- a/sqlite3_load_extension_omit.go
+++ b/sqlite3_load_extension_omit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_omit_load_extension
 // +build sqlite_omit_load_extension
 
 package sqlite3

--- a/sqlite3_load_extension_test.go
+++ b/sqlite3_load_extension_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !sqlite_omit_load_extension
 // +build !sqlite_omit_load_extension
 
 package sqlite3

--- a/sqlite3_opt_allow_uri_authority.go
+++ b/sqlite3_opt_allow_uri_authority.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_allow_uri_authority
 // +build sqlite_allow_uri_authority
 
 package sqlite3

--- a/sqlite3_opt_app_armor.go
+++ b/sqlite3_opt_app_armor.go
@@ -4,8 +4,8 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
-// +build !windows
-// +build sqlite_app_armor
+//go:build !windows && sqlite_app_armor
+// +build !windows,sqlite_app_armor
 
 package sqlite3
 

--- a/sqlite3_opt_foreign_keys.go
+++ b/sqlite3_opt_foreign_keys.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_foreign_keys
 // +build sqlite_foreign_keys
 
 package sqlite3

--- a/sqlite3_opt_fts3_test.go
+++ b/sqlite3_opt_fts3_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sqlite3

--- a/sqlite3_opt_fts5.go
+++ b/sqlite3_opt_fts5.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_fts5 || fts5
 // +build sqlite_fts5 fts5
 
 package sqlite3

--- a/sqlite3_opt_introspect.go
+++ b/sqlite3_opt_introspect.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_introspect
 // +build sqlite_introspect
 
 package sqlite3

--- a/sqlite3_opt_json1.go
+++ b/sqlite3_opt_json1.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_json || sqlite_json1 || json1
 // +build sqlite_json sqlite_json1 json1
 
 package sqlite3

--- a/sqlite3_opt_preupdate.go
+++ b/sqlite3_opt_preupdate.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sqlite3

--- a/sqlite3_opt_preupdate_hook.go
+++ b/sqlite3_opt_preupdate_hook.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_preupdate_hook
 // +build sqlite_preupdate_hook
 
 package sqlite3

--- a/sqlite3_opt_preupdate_hook_test.go
+++ b/sqlite3_opt_preupdate_hook_test.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_preupdate_hook
 // +build sqlite_preupdate_hook
 
 package sqlite3

--- a/sqlite3_opt_preupdate_omit.go
+++ b/sqlite3_opt_preupdate_omit.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !sqlite_preupdate_hook && cgo
 // +build !sqlite_preupdate_hook,cgo
 
 package sqlite3

--- a/sqlite3_opt_secure_delete.go
+++ b/sqlite3_opt_secure_delete.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_secure_delete
 // +build sqlite_secure_delete
 
 package sqlite3

--- a/sqlite3_opt_secure_delete_fast.go
+++ b/sqlite3_opt_secure_delete_fast.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_secure_delete_fast
 // +build sqlite_secure_delete_fast
 
 package sqlite3

--- a/sqlite3_opt_stat4.go
+++ b/sqlite3_opt_stat4.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_stat4
 // +build sqlite_stat4
 
 package sqlite3

--- a/sqlite3_opt_unlock_notify.go
+++ b/sqlite3_opt_unlock_notify.go
@@ -3,8 +3,8 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
-// +build cgo
-// +build sqlite_unlock_notify
+//go:build cgo && sqlite_unlock_notify
+// +build cgo,sqlite_unlock_notify
 
 package sqlite3
 

--- a/sqlite3_opt_unlock_notify_test.go
+++ b/sqlite3_opt_unlock_notify_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_unlock_notify
 // +build sqlite_unlock_notify
 
 package sqlite3

--- a/sqlite3_opt_userauth_omit.go
+++ b/sqlite3_opt_userauth_omit.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !sqlite_userauth
 // +build !sqlite_userauth
 
 package sqlite3
@@ -17,7 +18,7 @@ import (
 // If a database contains the SQLITE_USER table, then the
 // call to Authenticate must be invoked with an
 // appropriate username and password prior to enable read and write
-//access to the database.
+// access to the database.
 //
 // Return SQLITE_OK on success or SQLITE_ERROR if the username/password
 // combination is incorrect or unknown.
@@ -34,9 +35,10 @@ func (c *SQLiteConn) Authenticate(username, password string) error {
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	C.SQLITE_OK (0)
 //	C.SQLITE_ERROR (1)
-//  C.SQLITE_AUTH (23)
+//	C.SQLITE_AUTH (23)
 func (c *SQLiteConn) authenticate(username, password string) int {
 	// NOOP
 	return 0
@@ -65,9 +67,10 @@ func (c *SQLiteConn) AuthUserAdd(username, password string, admin bool) error {
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	C.SQLITE_OK (0)
 //	C.SQLITE_ERROR (1)
-//  C.SQLITE_AUTH (23)
+//	C.SQLITE_AUTH (23)
 func (c *SQLiteConn) authUserAdd(username, password string, admin int) int {
 	// NOOP
 	return 0
@@ -96,9 +99,10 @@ func (c *SQLiteConn) AuthUserChange(username, password string, admin bool) error
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	C.SQLITE_OK (0)
 //	C.SQLITE_ERROR (1)
-//  C.SQLITE_AUTH (23)
+//	C.SQLITE_AUTH (23)
 func (c *SQLiteConn) authUserChange(username, password string, admin int) int {
 	// NOOP
 	return 0
@@ -122,9 +126,10 @@ func (c *SQLiteConn) AuthUserDelete(username string) error {
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	C.SQLITE_OK (0)
 //	C.SQLITE_ERROR (1)
-//  C.SQLITE_AUTH (23)
+//	C.SQLITE_AUTH (23)
 func (c *SQLiteConn) authUserDelete(username string) int {
 	// NOOP
 	return 0
@@ -142,8 +147,9 @@ func (c *SQLiteConn) AuthEnabled() (exists bool) {
 // It is however exported for usage within SQL by the user.
 //
 // Returns:
+//
 //	0 - Disabled
-//  1 - Enabled
+//	1 - Enabled
 func (c *SQLiteConn) authEnabled() int {
 	// NOOP
 	return 0

--- a/sqlite3_opt_userauth_test.go
+++ b/sqlite3_opt_userauth_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_userauth
 // +build sqlite_userauth
 
 package sqlite3

--- a/sqlite3_opt_vacuum_full.go
+++ b/sqlite3_opt_vacuum_full.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_vacuum_full
 // +build sqlite_vacuum_full
 
 package sqlite3

--- a/sqlite3_opt_vacuum_incr.go
+++ b/sqlite3_opt_vacuum_incr.go
@@ -4,6 +4,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_vacuum_incr
 // +build sqlite_vacuum_incr
 
 package sqlite3

--- a/sqlite3_opt_vtable.go
+++ b/sqlite3_opt_vtable.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_vtable || vtable
 // +build sqlite_vtable vtable
 
 package sqlite3

--- a/sqlite3_opt_vtable_test.go
+++ b/sqlite3_opt_vtable_test.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_vtable || vtable
 // +build sqlite_vtable vtable
 
 package sqlite3

--- a/sqlite3_other.go
+++ b/sqlite3_other.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package sqlite3

--- a/sqlite3_solaris.go
+++ b/sqlite3_solaris.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build solaris
 // +build solaris
 
 package sqlite3

--- a/sqlite3_trace.go
+++ b/sqlite3_trace.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build sqlite_trace || trace
 // +build sqlite_trace trace
 
 package sqlite3

--- a/sqlite3_usleep_windows.go
+++ b/sqlite3_usleep_windows.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build cgo
 // +build cgo
 
 package sqlite3

--- a/sqlite3_windows.go
+++ b/sqlite3_windows.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package sqlite3

--- a/static_mock.go
+++ b/static_mock.go
@@ -3,6 +3,7 @@
 // Use of this source code is governed by an MIT-style
 // license that can be found in the LICENSE file.
 
+//go:build !cgo
 // +build !cgo
 
 package sqlite3


### PR DESCRIPTION
- Change module name to `github.com/SE-I-T-Digital/go-sqlcipher`
- Format README according to Markdownlint rules and replace broken links
  - learned that most of the documentation is originally from https://github.com/mattn/go-sqlite3
- In the workflow:
  - replace outdated [`go-acc`](https://github.com/ory/go-acc) with built-in `go test` commands
  - update targeted Go versions to latest 3 (`1.22`-`1.24`)
  - add concurrency settings
- Run `gofmt -l -s -w` to resolve gofmt issues from the [report card](https://goreportcard.com/report/github.com/SE-I-T-Digital/go-sqlcipher)