### PR TITLE
ci(pr): Pin action versions and set default permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/" 
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -11,6 +11,9 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
+permissions:  # added using https://github.com/step-security/secure-repo
+  contents: read
+
 jobs:
   test:
     name: Test
@@ -28,7 +31,7 @@ jobs:
       OS: ${{ matrix.os }}
       GO: ${{ matrix.go }}
     steps:
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version: ${{ matrix.go }}
           cache: false
@@ -40,7 +43,7 @@ jobs:
           go env -w CGO_CFLAGS="$(go env CGO_CFLAGS) -I/opt/homebrew/opt/openssl/include"
           go env -w CGO_LDFLAGS="$(go env CGO_LDFLAGS) -L/opt/homebrew/opt/openssl/lib"
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: "Tags: default"
         run: go test -race -v -coverprofile=coverage.out -tags ""
@@ -52,7 +55,7 @@ jobs:
         run: go test -race -v -coverprofile=coverage.out -tags "sqlite_vacuum_full"
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
@@ -71,14 +74,14 @@ jobs:
       OS: windows-latest
       GO: ${{ matrix.go }}
     steps:
-      - uses: msys2/setup-msys2@v2
+      - uses: msys2/setup-msys2@fb197b72ce45fb24f17bf3f807a388985654d1f2 # v2.29.0
         with:
           update: true
           install: mingw-w64-x86_64-toolchain mingw-w64-x86_64-sqlite3
           msystem: MINGW64
           path-type: inherit
 
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@19bb51245e9c80abacb2e91cc42b33fa478b8639 # v4.2.1
         with:
           go-version: ${{ matrix.go }}
 
@@ -87,7 +90,7 @@ jobs:
           echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
         shell: msys2 {0}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: "Tags: default"
         run: go build -race -v -tags ""
@@ -108,6 +111,6 @@ jobs:
         shell: msys2 {0}
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457 # v3.1.6
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Uses https://app.stepsecurity.io/secureworkflow to pin action versions to commit hashes and set default runner permissions

Adds github actions to dependabot configuration