### PR TITLE
chore(dependabot): Add options for cooldown and grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,11 +1,13 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    directory: "/" 
-    schedule:
-      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "wednesday"
+      interval: monthly
+    cooldown:
+      default-days: 14
+    groups:
+      actions-dependencies:
+        applies-to: version-updates
+        patterns:
+          - actions/*

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -11,7 +11,7 @@ concurrency:
   group: "${{ github.workflow }}-${{ github.ref }}"
   cancel-in-progress: true
 
-permissions:  # added using https://github.com/step-security/secure-repo
+permissions: # added using https://github.com/step-security/secure-repo
   contents: read
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        go: ["1.23", "1.24", "1.25"]
+        go: ["1.25", "1.26"]
       fail-fast: false
     env:
       OS: ${{ matrix.os }}
@@ -68,7 +68,7 @@ jobs:
 
     strategy:
       matrix:
-        go: ["1.23", "1.24", "1.25"]
+        go: ["1.25", "1.26"]
       fail-fast: false
     env:
       OS: windows-latest


### PR DESCRIPTION
Updates options in the Dependabot configuration:
- change to monthly checks for actions
- sets `cooldown` to 14 days to prevent security issues with new updates
- groups `actions/` updates aside from `codecov/` and `msys/`

Updates tested Go versions to latest two versions, per Go [support guidelines](https://go.dev/doc/devel/release#policy).